### PR TITLE
use default logger if Rails logger is unavailable

### DIFF
--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -62,7 +62,7 @@ class Happi::Client
 
   def default_logger
     if defined?(Rails)
-      Rails.logger
+      Rails.try(:logger) || Logger.new(STDOUT)
     else
       Logger.new(STDOUT)
     end


### PR DESCRIPTION
When called from a module, `Rails.logger` returns nil and Happi throws an exception. Use default logger instead.
