### PR TITLE
add use_json config variable to support JSON requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
     require 'happi'
 
     Happi::Client.configure do |config|
-      config.base_url = 'http://localhost:3000'
+      config.host = 'http://localhost:3000'
     end
 
     client = Happi::Client.new(
@@ -54,6 +54,18 @@ Or install it yourself as:
         params: JSON.dump({name: 'Test'}) } )[:document]
 
     puts document[:id]
+
+## Configuration
+
+```ruby
+Happi::Client.configure do |config|
+    host: 'http://localhost:8080',
+    port: 443,
+    timeout: 60,
+    version: 'v1'
+    use_json: false
+end
+```
 
 ## Contributing
 

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -87,11 +87,18 @@ class Happi::Client
 
   def connection
     @connection ||= Faraday.new(config.host) do |f|
-      f.request :multipart
       f.use FaradayMiddleware::OAuth2, config.oauth_token
       f.use FaradayMiddleware::ParseJson, content_type: 'application/json'
-      f.request :url_encoded
       f.adapter :net_http
+
+      if self.config.use_json
+        f.use FaradayMiddleware::EncodeJson
+        f.request :json
+        f.response :json
+      else
+        f.request :multipart
+        f.request :url_encoded
+      end
     end
   end
 

--- a/lib/happi/configuration.rb
+++ b/lib/happi/configuration.rb
@@ -4,11 +4,12 @@ class Happi::Configuration
     host: 'http://localhost:8080',
     port: 443,
     timeout: 60,
-    version: 'v1'
+    version: 'v1',
+    use_json: false
     }
   end
 
-  attr_accessor :oauth_token, :host, :port, :timeout, :version
+  attr_accessor :oauth_token, :host, :port, :timeout, :version, :use_json
 
   def initialize(options = {})
     self.class.defaults.merge(options).each do |key, value|

--- a/lib/happi/version.rb
+++ b/lib/happi/version.rb
@@ -1,3 +1,3 @@
 module Happi
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end


### PR DESCRIPTION
When config.use_json == true, happi should send the http request body as JSON. At the moment it encodes request body as a form.
