### PR TITLE
Make errors descend from StandardError

### DIFF
--- a/lib/happi/error.rb
+++ b/lib/happi/error.rb
@@ -1,4 +1,4 @@
-class Happi::Error < Exception
+class Happi::Error < StandardError
   class ClientError < self
     def message
       "A client error occurred"


### PR DESCRIPTION
If errors are derived from `Exception`, then:

```ruby
rescue => e
  puts e.message
```
won't work.