### PR TITLE
Allow Happi::Client instances to have their own configs instead of shari...

### DIFF
--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -4,10 +4,12 @@ require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/hash'
 
 class Happi::Client
-  delegate :config, to: self
+  def config
+    @config ||= self.class.config.dup
+  end
 
   def self.config
-    @config ||= Happi::Configuration.new
+    @global_config ||= Happi::Configuration.new
   end
 
   def self.configure

--- a/lib/happi/version.rb
+++ b/lib/happi/version.rb
@@ -1,3 +1,3 @@
 module Happi
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,11 +1,82 @@
 require 'spec_helper'
 
+class DerivedClient < Happi::Client; end
+
 describe Happi::Client do
-  describe 'call' do
+  describe '.new' do
+    let(:default_port) { Happi::Configuration.defaults[:port] }
+    let(:class_level_port) { 80 }
+    let(:instance_level_port) { 8080 }
+    let(:derived_class_level_port) { 8081 }
+    let(:config_port) { described_class.new.config.port }
+    let(:derived_config_port) { DerivedClient.new.config.port }
 
-  end
+    context 'with no supplied config' do
+      it 'uses the default config for the base class' do
+        expect(config_port).to eq(default_port)
+      end
 
-  describe 'raise_error' do
+      it 'uses the default config for the derived class' do
+        expect(derived_config_port).to eq(default_port)
+      end
+    end
 
+    context 'with class level config for the base class' do
+      before do
+        described_class.configure { |config| config.port = class_level_port }
+      end
+
+      it 'overrides the default config for the base class' do
+        expect(config_port).to eq(class_level_port)
+      end
+
+      it 'does not override the default config for the derived class' do
+        expect(derived_config_port).to_not eq(class_level_port)
+      end
+    end
+
+    context 'with class level config for the derived class' do
+      before do
+        DerivedClient.configure { |config| config.port = derived_class_level_port }
+      end
+
+      it 'does not affect the config for the base class' do
+        expect(config_port).to_not eq(derived_class_level_port)
+      end
+
+      it 'overrides the default config for the derived class' do
+        expect(derived_config_port).to eq(derived_class_level_port)
+      end
+    end
+
+    context 'with instance level config for the base class' do
+      before do
+        described_class.configure { |config| config.port = class_level_port }
+      end
+
+      it 'overrides the class config for only that base class instance' do
+        expect(Happi::Client.new(port: instance_level_port).config.port).to eq(instance_level_port)
+        expect(config_port).to_not eq(instance_level_port)
+      end
+
+      it 'does not affect the config for an instance of the derived class' do
+        expect(derived_config_port).to_not eq(instance_level_port)
+      end
+    end
+
+    context 'with instance level config for the derived class' do
+      before do
+        described_class.configure { |config| config.port = class_level_port }
+      end
+
+      it 'does not affect the config for an instance of the base class' do
+        expect(config_port).to_not eq(instance_level_port)
+      end
+
+      it 'overrides the class config for only that derived class instance' do
+        expect(DerivedClient.new(port: instance_level_port).config.port).to eq(instance_level_port)
+        expect(derived_config_port).to_not eq(instance_level_port)
+      end
+    end
   end
 end


### PR DESCRIPTION
...ng them across the class to avoid one instance from clobbering the settings of another

This fixes:
https://jobready.atlassian.net/browse/AV-2448
https://rollbar.com/JobReady/AVETARS/items/1163/
