### PR TITLE
Initialize server errors with response, not just client errors

### DIFF
--- a/lib/happi/error.rb
+++ b/lib/happi/error.rb
@@ -1,12 +1,12 @@
 class Happi::Error < StandardError
+  attr_reader :response
+
+  def initialize(msg = nil, response = nil)
+    super(msg)
+    @response = response
+  end
+
   class ClientError < self
-    attr_reader :response
-
-    def initialize(msg = nil, response = nil)
-      super(msg)
-      @response = response
-    end
-
     def message
       "A client error occurred"
     end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Happi::Error do
+  describe '.new' do
+    context 'with 1 argument' do
+      let(:error) { Happi::Error.new('message') }
+      specify { expect(error.message).to eq('message') }
+      specify { expect(error.response).to be nil }
+    end
+
+    context 'with 2 arguments' do
+      let(:error) { Happi::Error.new('message', 'response') }
+      specify { expect(error.message).to eq('message') }
+      specify { expect(error.response).to eq('response') }
+    end
+  end
+end


### PR DESCRIPTION
I changed the happi response code in an earlier PR, to put the response into the exception object we raise. However I only fixed the constructor for the client error classes, which means happi would raise an exception when trying to create the server exception.
