### PR TITLE
Use token type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2018-02-23
+### Added
+- Ability to set `token_type` in configuration and pass this into `FaradayMiddleware::OAuth2` to avoid `faraday_middleware` 0.11.0 warning about using the default token type. Set `token_type: 'bearer'` to only pass the oauth token as an Authorization header instead of both a header and query string parameter.
+- This CHANGELOG.
+
+[Unreleased]: https://github.com/jobready/happi/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jobready/happi/compare/v0.2.0...v0.3.0

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -94,7 +94,7 @@ class Happi::Client
 
   def connection
     @connection ||= Faraday.new(config.host) do |f|
-      f.use FaradayMiddleware::OAuth2, config.oauth_token
+      f.use FaradayMiddleware::OAuth2, config.oauth_token, connection_options
       f.use FaradayMiddleware::ParseJson, content_type: 'application/json'
 
       if self.config.use_json
@@ -107,6 +107,14 @@ class Happi::Client
       end
 
       f.adapter :net_http
+    end
+  end
+
+  def connection_options
+    if config.token_type.present?
+      { token_type: config.token_type }
+    else
+      { }
     end
   end
 

--- a/lib/happi/configuration.rb
+++ b/lib/happi/configuration.rb
@@ -1,16 +1,23 @@
 class Happi::Configuration
   def self.defaults
-     {
-    host: 'http://localhost:8080',
-    port: 443,
-    timeout: 60,
-    version: 'v1',
-    use_json: false,
-    log_level: :info
+    {
+      host: 'http://localhost:8080',
+      port: 443,
+      timeout: 60,
+      version: 'v1',
+      use_json: false,
+      log_level: :info
     }
   end
 
-  attr_accessor :oauth_token, :host, :port, :timeout, :version, :use_json, :log_level
+  attr_accessor :oauth_token,
+                :host,
+                :port,
+                :timeout,
+                :version,
+                :use_json,
+                :log_level,
+                :token_type
 
   def initialize(options = {})
     self.class.defaults.merge(options).each do |key, value|

--- a/lib/happi/version.rb
+++ b/lib/happi/version.rb
@@ -1,3 +1,3 @@
 module Happi
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -79,4 +79,24 @@ describe Happi::Client do
       end
     end
   end
+
+  describe '#connection_options' do
+    subject { client.connection_options }
+
+    context 'where config.token_type present' do
+      let(:client) { described_class.new(token_type: 'bearer') }
+
+      specify do
+        expect(subject).to eq(token_type: 'bearer')
+      end
+    end
+
+    context 'where config.token_type not present' do
+      let(:client) { described_class.new }
+
+      specify do
+        expect(subject).to eq({})
+      end
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,13 +1,32 @@
 require 'spec_helper'
 
 describe Happi::Configuration do
-  describe 'options' do
-    specify { expect(Happi::Configuration.new(host: 'http://www.google.com').host).to eql('http://www.google.com') }
-    specify { expect(Happi::Configuration.new(port: 80).port).to eql(80) }
+  it { is_expected.to respond_to(:oauth_token) }
+  it { is_expected.to respond_to(:host) }
+  it { is_expected.to respond_to(:port) }
+  it { is_expected.to respond_to(:timeout) }
+  it { is_expected.to respond_to(:version) }
+  it { is_expected.to respond_to(:use_json) }
+  it { is_expected.to respond_to(:log_level) }
+  it { is_expected.to respond_to(:token_type) }
 
-    specify do
-      Happi::Client.configure { |config| config.host = 'http://localhost:3000' }
-      expect(Happi::Client.config.host).to eq 'http://localhost:3000'
+  describe '.new' do
+    context 'with options' do
+      let(:config) { described_class.new(host: 'http://www.example.com', port: 80) }
+
+      it 'overrides default values for options' do
+        expect(config.host).to eq('http://www.example.com')
+        expect(config.port).to eq(80)
+      end
+    end
+
+    context 'without options' do
+      let(:config) { described_class.new }
+
+      it 'uses default values for options' do
+        expect(config.host).to eq('http://localhost:8080')
+        expect(config.port).to eq(443)
+      end
     end
   end
 end


### PR DESCRIPTION
After upgrading to faraday_middleware 0.11.0, the following warning starts appearing whenever a happi client connection is made:

> Warning: FaradayMiddleware::OAuth2 initialized with default token_type - token will be added as both a query string parameter and an Authorization header. In the next major release, tokens will be added exclusively as an Authorization header by default. Please visit https://github.com/lostisland/faraday_middleware/wiki for more information.

My understanding is that it is preferable to only send tokens as an authorization header for security reasons eg so tokens don't appear in logs. What I've tried to do with this PR is to keep the existing behaviour of happi and just add on top. So for apps currently using happi, there will be no change required. But for apps that wish to stop the above warning, they can configure their happi client with a token type:

```
class Tyims::UploadClient < Happi::Client
  def initialize
    super(
      host: ENV['TYIMS_UPLOAD_HOST'],
      oauth_token: ENV['TYIMS_UPLOAD_TOKEN'],
      token_type: 'bearer',
    )
  end
end
```