### PR TITLE
[NEP-19931] bump to rc2, adds some middleware

### DIFF
--- a/happi.gemspec
+++ b/happi.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'pry'
 end

--- a/happi.gemspec
+++ b/happi.gemspec
@@ -23,9 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-follow_redirects', '~> 0.3'
   spec.add_dependency 'faraday-http', '~> 2.0'
   spec.add_dependency 'faraday-multipart', '~> 1.1'
-  spec.add_dependency 'faraday-oauth', '~> 0.1'
+  spec.add_dependency 'faraday-retry', '~> 2.3'
   spec.add_dependency 'activemodel', '>= 6.0'
-  spec.add_dependency 'oauth2', '~> 2.0'
   spec.add_dependency 'mime-types', '~> 3.7'
   spec.add_dependency 'multi_json', '~> 1.15'
 

--- a/happi.gemspec
+++ b/happi.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Simple faraday client wrapper preconfigured for specific usecase}
   spec.homepage      = "https://github.com/rdytech/happi"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.2.0' # faraday gem supports only non-EOL versions of Ruby
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/happi.gemspec
+++ b/happi.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday-follow_redirects', '~> 0.3'
   spec.add_dependency 'faraday-http', '~> 2.0'
   spec.add_dependency 'faraday-multipart', '~> 1.1'
+  spec.add_dependency 'faraday-oauth', '~> 0.1'
   spec.add_dependency 'activemodel', '>= 6.0'
   spec.add_dependency 'oauth2', '~> 2.0'
   spec.add_dependency 'mime-types', '~> 3.7'

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -106,7 +106,7 @@ class Happi::Client
   def connection
     @connection ||= Faraday.new(config.host) do |f|
       f.request :authorization, 'Bearer', -> { config.oauth_token }
-      f.request :retry, retry_options
+      f.request :retry, **retry_options
       f.use Faraday::FollowRedirects::Middleware  # default limit is 3
 
       if self.config.use_json

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -1,6 +1,7 @@
 require 'faraday'
 require 'faraday/follow_redirects'
 require 'faraday/multipart'
+require 'faraday/retry'
 require 'faraday/http'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/hash'

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -2,6 +2,7 @@ require 'faraday'
 require 'faraday/follow_redirects'
 require 'faraday/multipart'
 require 'faraday/http'
+require 'faraday/oauth'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/hash'
 
@@ -96,11 +97,11 @@ class Happi::Client
 
   def connection
     @connection ||= Faraday.new(config.host) do |f|
-      f.use FaradayMiddleware::OAuth2, config.oauth_token, connection_options
+      f.use Faraday::OAuth, config.oauth_token, connection_options
+      f.use Faraday::FollowRedirects::Middleware
       f.use JSON, content_type: 'application/json'
 
       if self.config.use_json
-        f.use FaradayMiddleware::EncodeJson
         f.request :json
         f.response :json
       else
@@ -108,7 +109,7 @@ class Happi::Client
         f.request :url_encoded
       end
 
-      f.adapter :net_http
+      f.adapter :http
     end
   end
 

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -2,7 +2,6 @@ require 'faraday'
 require 'faraday/follow_redirects'
 require 'faraday/multipart'
 require 'faraday/http'
-require 'faraday/oauth'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/hash'
 
@@ -97,9 +96,8 @@ class Happi::Client
 
   def connection
     @connection ||= Faraday.new(config.host) do |f|
-      f.use Faraday::OAuth, config.oauth_token, connection_options
-      f.use Faraday::FollowRedirects::Middleware
-      f.use JSON, content_type: 'application/json'
+      f.request :authorization, 'Bearer', -> { config.oauth_token }
+      f.use Faraday::FollowRedirects::Middleware, limit: 3
 
       if self.config.use_json
         f.request :json

--- a/lib/happi/client.rb
+++ b/lib/happi/client.rb
@@ -94,10 +94,20 @@ class Happi::Client
     end]
   end
 
+  def retry_options
+    {
+      max: 3,
+      interval: 0.05,
+      interval_randomness: 0.5,
+      backoff_factor: 2
+    }
+  end
+
   def connection
     @connection ||= Faraday.new(config.host) do |f|
       f.request :authorization, 'Bearer', -> { config.oauth_token }
-      f.use Faraday::FollowRedirects::Middleware, limit: 3
+      f.request :retry, retry_options
+      f.use Faraday::FollowRedirects::Middleware  # default limit is 3
 
       if self.config.use_json
         f.request :json

--- a/lib/happi/version.rb
+++ b/lib/happi/version.rb
@@ -1,3 +1,3 @@
 module Happi
-  VERSION = '1.0.0-rc'
+  VERSION = '1.0.0-rc2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'simplecov'
+require 'pry'
+
 SimpleCov.start
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w[.. lib])


### PR DESCRIPTION
https://jobready.atlassian.net/browse/NEP-19931

With Faraday 2 architecture extracting functionality to modularisation with separate gems 
we can add in some common middleware gems as part of this upgrade

https://github.com/tisba/faraday-follow-redirects

https://github.com/lostisland/faraday-http

https://github.com/lostisland/faraday-multipart

https://github.com/lostisland/faraday-retry

